### PR TITLE
httpLink for GraphQL was hardcoded to localhost:3001 but the Render d…

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,7 +6,7 @@ import { setContext } from '@apollo/client/link/context';
 
 // Set up the GraphQL API endpoint
 const httpLink = createHttpLink({
-  uri: 'http://localhost:3001/graphql',
+  uri: 'http://localhost:10000/graphql',
 });
 
 // Attach JWT token to each request


### PR DESCRIPTION
…eploy uses port 10000. Changing port and will re-test addUser API after re-deploy.